### PR TITLE
Fixes for Mechanical Marquise

### DIFF
--- a/src/app/models/marquise-dc.ts
+++ b/src/app/models/marquise-dc.ts
@@ -98,14 +98,10 @@ export class MarquiseBotDC extends Bot {
 
     if (this.customData.currentSuit === 'bird') {
 
-      const isChallengingPlus = this.difficulty === 'Challenging' || this.difficulty === 'Nightmare';
-
       const base2 = [
         translate.instant(`SpecificDaylight.Mechanical Marquise (DC).Bird0`),
 
         translate.instant(`SpecificDaylight.Mechanical Marquise (DC).Bird1`, { totalWarriors }),
-
-        isChallengingPlus ? translate.instant(`SpecificDaylight.Mechanical Marquise.BirdChallenging`) : '',
 
         translate.instant(`SpecificDaylight.Mechanical Marquise (DC).Bird2`),
 

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -119,7 +119,7 @@
       "Setup0": "Form a supply of 25 warriors near you.",
       "Setup1": "Place the keep token in a random corner clearing.",
       "Setup2": "Place a warrior in each clearing, except the corner clearing diagonally opposite from the keep. Place an extra warrior in the clearing with the keep token. _(Place 12 warriors in total.)_",
-      "Setup3": "Place 1 sawmill, 1 workshop and 1 recruiter randomly among the clearing with the keep token and those clearings adjacent with up to one building per clearing.",
+      "Setup3": "Place 1 sawmill, 1 workshop and 1 recruiter randomly among the clearings adjacent to the clearing with the keep token with up to one building per clearing.",
       "Setup4": "Collect your remaining 15 buildings and place them near you."
     }
   },
@@ -145,8 +145,8 @@
     "Mechanical Marquise": {
       "Easy": "Whenever you **Recruit**, instead place only two warriors.",
       "Normal": "Nothing is changed.",
-      "Challenging": "Whenever you **Recruit**, instead place four warriors.",
-      "Nightmare": "Whenever you **Recruit**, instead place five warriors. At the end of Evening, score one victory point."
+      "Challenging": "Whenever you **Recruit**, also place two warriors in the ordered clearing you rule of highest priority.",
+      "Nightmare": "Whenever you **Recruit**, also place two warriors in the ordered clearing you rule of highest priority. At the end of Evening, score one victory point."
     },
     "Electric Eyrie (DC)": {
       "Easy": "Whenever you **Recruit** for bird, instead place one fewer warrior.",
@@ -167,10 +167,10 @@
       "Nightmare": "You **Organize** if a clearing has two or more Alliance warriors. At the end of Evening, score one victory point per two players (rounded up)."
     },
     "Mechanical Marquise (DC)": {
-      "Easy": "Whenever you **Recruit**, instead place only two warriors.",
+      "Easy": "Whenever you **Recruit**, instead place only three warriors.",
       "Normal": "Nothing is changed.",
-      "Challenging": "Whenever you **Recruit**, also place two warriors in the ordered clearing you rule of highest priority.",
-      "Nightmare": "Whenever you **Recruit**, also place two warriors in the ordered clearing you rule of highest priority. At the end of Evening, score one victory point per two players (rounded up)."
+      "Challenging": "Whenever you **Recruit**, instead place five warriors.",
+      "Nightmare": "Whenever you **Recruit**, instead place five warriors. At the end of Evening, score one victory point per two players (rounded up)."
     }
   },
   "SpecificRules": {
@@ -355,9 +355,8 @@
       "Blitz": "Find the clearing you rule of the highest priority without any enemy pieces. Move all but one warrior from the clearing. Then, battle in the destination clearing.",
       "Bird0": "Battle in all clearings. _(Defender is the player with most pieces, then victory points.)_",
       "Bird1": "Recruit {{totalWarriors}} warrior(s) evenly among the two lowest priority clearings you rule. If you rule only one clearing, place all {{totalWarriors}} there. Score **vp:1** for every two warriors that could not be recruited.",
-      "Bird2": "Build a building of the type with the most pieces on the map in a clearing you rule with the most Marquise Warriors.<br>_(On a tie between sawmills and any other building types, place a sawmill. On a tie between workshops and recruiters but not sawmills, place a recruiter.)_",
+      "Bird2": "Build a building of the type with the most pieces on the map in a clearing you rule with the most Marquise Warriors.<br>_(On a tie between sawmills and any other building types, place a sawmill. On a tie between workshops and recruiters but not sawmills, place a workshop.)_",
       "Bird3": "Move all but three of your warriors from each clearing to the adjacent clearing with the most enemy pieces. Then battle in each clearing you moved into.",
-      "BirdChallenging": "Place two warriors in the ordered clearing you rule of the highest priority.",
       "Suit0": "Battle in each **card:{{suit}}** clearing. _(Defender is the player with most pieces, then victory points.)_",
       "Suit1": "Recruit {{totalWarriors}} warriors evenly spread across **card:{{suit}}** clearings you rule. Score **vp:1** for every two warriors that could not be recruited.<br>_(**Clearing tie**: Place warriors into clearings with highest priority first.)_",
       "Suit2": "Build a **building:{{building}}** in a clearing you rule with the most Marquise warriors.",

--- a/src/assets/i18n/fr-FR.json
+++ b/src/assets/i18n/fr-FR.json
@@ -119,7 +119,7 @@
             "Setup0": "Formez une réserve de 25 guerriers près de vous.",
             "Setup1": "Placez le jeton du donjon dans une clairière en coin du plateau au hasard.",
             "Setup2": "Placez 1 guerrier dans chaque clairière, excepté dans celle diagonalement opposée au donjon. Placez 1 guerrier supplémentaire dans la clairière du donjon. _(Placez 12 guerriers au total.)_",
-            "Setup3": "Placez au hasard 1 scierie, 1 atelier et 1 recruteur parmi la clairière du donjon et les clairières adjacentes. (Placez-en 3 au total. Un par clairière.)",
+            "Setup3": "Placez au hasard 1 scierie, 1 atelier et 1 recruteur parmi les clairières adjacentes à la clairière du donjon. (Placez-en 3 au total. Un par clairière.)",
             "Setup4": "Prenez vos bâtiments restants (5 de chaque type) et placez-les près de vous."
         }
     },
@@ -167,10 +167,10 @@
             "Nightmare": "Effectuez l'action **Organisation** pour les clairières avec au moins 2 guerriers de l'Alliance. A la fin du Crépuscule, marquez 1 point de victoire par paire de joueurs humains _(arrondi supérieur)_."
         },
         "Mechanical Marquise (DC)": {
-            "Easy": "Lors du **Recrutement**, ne placez que 2 guerriers.",
+            "Easy": "Lors du **Recrutement**, ne placez que 3 guerriers.",
             "Normal": "Mode par défaut.",
-            "Challenging": "Lors du **Recrutement**, placez également 2 guerriers dans la clairière contrôlée de la couleur de l'ordre de plus haute priorité.",
-            "Nightmare": "Lors du **Recrutement**, placez également 2 guerriers dans la clairière contrôlée de la couleur de l'ordre de plus haute priorité. A la fin du Crépuscule, marquez 1 point de victoire par paire de joueurs humains _(arrondi supérieur)_."
+            "Challenging": "Lors du **Recrutement**, placez plutôt 5 guerriers.",
+            "Nightmare": "Lors du **Recrutement**, placez plutôt 5 guerriers. A la fin du Crépuscule, marquez 1 point de victoire par paire de joueurs humains _(arrondi supérieur)_."
         }
     },
     "SpecificRules": {
@@ -355,9 +355,8 @@
             "Blitz": "Sélectionnez la clairière contrôlée sans pièces adverses ayant la plus haute priorité. Déplacez tous vos guerriers, sauf 1, depuis cette clairière, puis initiez un combat dans la clairière d'arrivée.",
             "Bird0": "**Combattez** dans toutes les clairières. _(Le défenseur est le joueur avec le plus de pièces, puis le plus de PV.)_",
             "Bird1": "Recrutez  {{totalWarriors}} guerriers répartis uniformément dans les 2 clairières contrôlées ayant la priorité la plus faible. Si vous ne contrôlez qu'une clairière, placez-y la totalité des {{totalWarriors}} guerriers. Marquez **vp:1** par paire de guerriers n'ayant pas pu être placés.",
-            "Bird2": "**Construisez** un bâtiment du type le plus construit dans la clairière contrôlée avec le plus de vos guerriers.<br>_(Si égalité, les scieries, sinon les recruteurs.)_",
+            "Bird2": "**Construisez** un bâtiment du type le plus construit dans la clairière contrôlée avec le plus de vos guerriers.<br>_(Si égalité, les scieries, sinon les ateliers.)_",
             "Bird3": "**Déplacez** tous vos guerriers, sauf 3, depuis chaque clairière vers la clairière adjacente avec le plus de pièces adverses. _(Chaque guerrier ne peut être déplacé qu'une fois.)_ Puis initiez un combat dans chaque clairière d'arrivée.",
-            "BirdChallenging": "**Recrutez** 2 guerriers dans la clairière contrôlée ayant la plus haute priorité.",
             "Suit0": "**Combattez** dans toutes les clairières **card:{{suit}}**. _(Le défenseur est le joueur avec le plus de pièces, puis le plus de PV.)_",
             "Suit1": "**Recrutez** {{totalWarriors}} guerriers répartis uniformément dans les clairières **card:{{suit}}** contrôlées. Placez les guerriers en priorité dans les clairières **card:{{suit}}** ayant la plus haute priorité. Marquez **vp:1** par paire de guerriers n'ayant pas pu être placés.",
             "Suit2": "**Construisez** 1 **building:{{building}}** dans la clairière contrôlée avec le plus de vos guerriers.",


### PR DESCRIPTION
- MM DC doesn't recruit the bonus 2 warriors in expert Escalated Daylight, so that string was removed.
- MM DC can't place a starting building in the clearing with the keep; fixed that line
- Fixed the swapped strings for MM and MM DC difficulty levels
- MM DC has priority Sawmill > Workshop > Recruiter; fixed that line