### PR TITLE
Update variable name to match coded instance

### DIFF
--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -283,7 +283,7 @@
       "Recruit": "Recruit {{totalForSuit}} warrior(s) in a {{suitText}} clearing with a roost. {{recruitText}}<br>_(**Ties**: Recruit in such a clearing with the most enemy pieces, then fewest Eyrie warriors, then lowest priority.)_",
       "Move": "Move from the {{suitText}} clearing you rule with the most of your warriors to an adjacent clearing. Leave enough warriors to exactly rule the origin clearing or {{totalForSuit}}, whichever is higher.<br>_(**Destination Ties**: Move to such a clearing with no roost, then fewest enemy pieces, then lowest priority.)_",
       "Battle": "Battle in a {{suitText}} clearing against the player with the most buildings there. {{extraHit}}<br>_(**Clearing Ties**: Battle in such a clearing with no roost, then most defenseless buildings, then lowest priority.)_<br>_(**Defender Ties**: Battle such a player with the most pieces there, then the player with the most victory points.)_",
-      "ExtraDealExtraHit": "**Deal an extra hit.**",
+      "ExtraHit": "**Deal an extra hit.**",
       "ExtraDecree": "You should have added at least 2 bird cards to the decree.",
       "ExtraRelentless": "Remove all defenseless tokens and buildings in any clearing with Eyrie warriors.",
       "ExtraRecruit": "If you cannot place a warrior, you fall into turmoil.",


### PR DESCRIPTION
Figured there were two easy ways to approach this. Either change the variable name in the i18n config, or update the references elsewhere in the code to match what was previously in the i18n config. 

I went with the least-effort approach, but if this is the wrong way to do it, I'd happily update the PR to keep the i18n config the same and change the coded references instead.